### PR TITLE
added support XDG Base Directory specification

### DIFF
--- a/GModCEFCodecFix.py
+++ b/GModCEFCodecFix.py
@@ -152,13 +152,14 @@ from hashlib import sha256
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
 from bsdiff4 import file_patch
-from xdg import XDG_DATA_HOME
 
 # Specific platform imports
 if sys.platform == "win32":
 	import winreg
 else:
 	from pathlib import Path
+if sys.platform == "linux":
+	from xdg import XDG_DATA_HOME
 
 if len(sys.argv) >= 3:
 	# sys.argv[0] is always the script/exe path

--- a/GModCEFCodecFix.py
+++ b/GModCEFCodecFix.py
@@ -152,6 +152,7 @@ from hashlib import sha256
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
 from bsdiff4 import file_patch
+from xdg import XDG_DATA_HOME
 
 # Specific platform imports
 if sys.platform == "win32":
@@ -196,12 +197,13 @@ elif sys.platform == "darwin":
 else:
 	# Linux
 	homeDir = str(Path.home())
+	dataDir = str(XDG_DATA_HOME)
 	if os.path.isdir(os.path.join(homeDir, ".steam", "steam")):
 		steamPath = os.path.join(homeDir, ".steam", "steam")
-	elif os.path.isdir(os.path.join(homeDir, ".local", "share", "Steam")):
-		steamPath = os.path.join(homeDir, ".local", "share", "Steam")
+	elif os.path.isdir(os.path.join(dataDir, "Steam")):
+		steamPath = os.path.join(dataDir, "Steam")
 
-	steamPathHints["linux"] = "Is it installed somewhere other than " + os.path.join(homeDir, ".steam", "steam") + " or " + os.path.join(homeDir, ".local", "share", "Steam") + " ?"
+	steamPathHints["linux"] = "Is it installed somewhere other than " + os.path.join(homeDir, ".steam", "steam") + " or " + os.path.join(dataDir, "Steam") + " ?"
 
 if steamPath:
 	print("Steam Path:\n" + steamPath + "\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ git+git://github.com/winterphoenix/steamfiles@patch-1
 steamid
 bsdiff4
 psutil; sys_platform == 'linux'
-xdg
+xdg; sys_platform == 'linux'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ git+git://github.com/winterphoenix/steamfiles@patch-1
 steamid
 bsdiff4
 psutil; sys_platform == 'linux'
+xdg


### PR DESCRIPTION
this adds support for the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) for Linux/BSD

as it stands right now, GModCEFCodecFix is hardcoded to look for the steam data folder in `~/.local/share/Steam`, assuming it doesn't find it in the `~/.steam` symbolic link

Steam, to a [certain extent](https://github.com/ValveSoftware/steam-for-linux/issues/1890), supports the specification such that it will respect the `XDG_DATA_HOME` environment variable for its data folder - therefore, this changes the hardcoded path previously mentioned to `$XDG_DATA_HOME/Steam` where applicable

this has been tested and works on my [Artix Linux](https://artixlinux.org/) machine