### PR TITLE
Fix for script not accepting "no" option

### DIFF
--- a/GModCEFCodecFix.py
+++ b/GModCEFCodecFix.py
@@ -563,11 +563,13 @@ if gmodEXELaunchOptionsLen == 1:
 
 		shouldLaunch = "yes" if autoMode is not False else input(">>> ")
 		try:
-			shouldLaunch = shouldLaunch.lower()
-			if shouldLaunch == "yes" or shouldLaunch == "y":
+			shouldLaunch = shouldLaunch.lower() 
+			shouldLaunch = shouldLaunch.strip() # strip of whitespaces
+			
+			if shouldLaunch in ["yes","y"]:
 				validShouldLaunch = True
 				shouldLaunch = True
-			elif shouldLaunch == "no" or shouldLaunch == "n":
+			elif shouldLaunch in ["no","n"]:
 				validShouldLaunch = True
 				shouldLaunch = False
 			else:


### PR DESCRIPTION
Script, at least on URXVT (Linux), only responds to "n" rather than "no". I have added some "safety nets" to ensure the correct input is given to the script.