### PR TITLE
Add kgx (GNOME Console) support

### DIFF
--- a/GModCEFCodecFix.py
+++ b/GModCEFCodecFix.py
@@ -51,7 +51,8 @@ possibleTerminals = [
 	"tilda",
 	"alacritty",
 	"hyper",
-	"foot"
+	"foot",
+	"kgx"
 ]
 termNotFoundError = "GModCEFCodecFix could not find a suitable Terminal Emulator!\n\tIf one is installed, Contact Us about this:\n- Discord: https://www.solsticegamestudios.com/chat.html\n- Email: contact@solsticegamestudios.com"
 


### PR DESCRIPTION
Added kgx, GNOME's new default Terminal application, to the list of supported Terminals.