### PR TITLE
Use Temporary/Cache file storage per OS

### DIFF
--- a/GModCEFCodecFix.py
+++ b/GModCEFCodecFix.py
@@ -545,7 +545,6 @@ if fileNoMatchOriginal:
 if len(filesToUpdate) > 0:
 	print("\nFixing Files...")
 
-	curDir = os.path.dirname(sys.executable) if getattr(sys, "frozen", False) else os.path.dirname(os.path.normcase(os.path.realpath(__file__)))
 	if sys.platform == "linux":
 		cacheDirLinux = str(XDG_CACHE_HOME)
 		cacheDir = os.path.join(cacheDirLinux, "GModCEFCodecFixFiles")

--- a/GModCEFCodecFix.py
+++ b/GModCEFCodecFix.py
@@ -167,6 +167,7 @@ else:
 	from pathlib import Path
 if sys.platform == "linux":
 	from xdg import XDG_DATA_HOME
+	from xdg import XDG_CACHE_HOME
 
 if len(sys.argv) >= 3:
 	# sys.argv[0] is always the script/exe path
@@ -544,9 +545,15 @@ if len(filesToUpdate) > 0:
 	print("\nFixing Files...")
 
 	curDir = os.path.dirname(sys.executable) if getattr(sys, "frozen", False) else os.path.dirname(os.path.normcase(os.path.realpath(__file__)))
-	cacheDir = os.path.join(curDir, "GModCEFCodecFixFiles")
+	if sys.platform == "linux":
+		cacheDirLinux = str(XDG_CACHE_HOME)
+		cacheDir = os.path.join(cacheDirLinux, "GModCEFCodecFixFiles")
+	if sys.platform == "win32":
+		cacheDir = os.path.abspath("%appdata%/Temp/CEFCodecFixFiles")
+	if sys.platform == "darwin":
+		cacheDir = os.path.abspath("~/Library/Caches/GModCEFCodecFixFiles")
 	cacheExists = os.path.isdir(cacheDir)
-
+    	
 	if not cacheExists:
 		os.mkdir(cacheDir)
 

--- a/GModCEFCodecFix.py
+++ b/GModCEFCodecFix.py
@@ -554,7 +554,7 @@ if len(filesToUpdate) > 0:
 		cacheDir = os.path.join(cacheDirWin, "GModCEFCodecFixFiles")
 	if sys.platform == "darwin":
 		cacheDirMac = str(homedir + "/Library/Caches/")
-		cacheDir = os.path.abspath(cacheDirMac, "GModCEFCodecFixFiles")
+		cacheDir = os.path.join(cacheDirMac, "GModCEFCodecFixFiles")
 	cacheExists = os.path.isdir(cacheDir)
 	if not cacheExists:
 		os.mkdir(cacheDir)

--- a/GModCEFCodecFix.py
+++ b/GModCEFCodecFix.py
@@ -16,7 +16,6 @@
 
 import sys
 import os
-homedir = os.path.expanduser("~")
 from subprocess import Popen
 
 if sys.version_info.major != 3:
@@ -545,6 +544,7 @@ if fileNoMatchOriginal:
 if len(filesToUpdate) > 0:
 	print("\nFixing Files...")
 
+	homedir = os.path.expanduser("~")
 	if sys.platform == "linux":
 		cacheDirLinux = str(XDG_CACHE_HOME)
 		cacheDir = os.path.join(cacheDirLinux, "GModCEFCodecFixFiles")
@@ -555,6 +555,7 @@ if len(filesToUpdate) > 0:
 		cacheDirMac = str(homedir + "/Library/Caches/")
 		cacheDir = os.path.join(cacheDirMac, "GModCEFCodecFixFiles")
 	cacheExists = os.path.isdir(cacheDir)
+	
 	if not cacheExists:
 		os.mkdir(cacheDir)
 

--- a/GModCEFCodecFix.py
+++ b/GModCEFCodecFix.py
@@ -16,6 +16,7 @@
 
 import sys
 import os
+homedir = os.path.expanduser("~")
 from subprocess import Popen
 
 if sys.version_info.major != 3:
@@ -549,11 +550,12 @@ if len(filesToUpdate) > 0:
 		cacheDirLinux = str(XDG_CACHE_HOME)
 		cacheDir = os.path.join(cacheDirLinux, "GModCEFCodecFixFiles")
 	if sys.platform == "win32":
-		cacheDir = os.path.abspath("%appdata%/Temp/CEFCodecFixFiles")
+		cacheDirWin = str(homedir + "\\AppData\\Local\\Temp\\")
+		cacheDir = os.path.join(cacheDirWin, "GModCEFCodecFixFiles")
 	if sys.platform == "darwin":
-		cacheDir = os.path.abspath("~/Library/Caches/GModCEFCodecFixFiles")
+		cacheDirMac = str(homedir + "/Library/Caches/")
+		cacheDir = os.path.abspath(cacheDirMac, "GModCEFCodecFixFiles")
 	cacheExists = os.path.isdir(cacheDir)
-    	
 	if not cacheExists:
 		os.mkdir(cacheDir)
 


### PR DESCRIPTION
In this commit, GModCEFCodecFix.py now uses temporary file storage paths per OS for storing GModCEFCodecFixFiles directory.

This ensures against write access issues and prevents files from being placed in unwanted locations such as the user's Desktop or a path in which we cannot ensure write access.