### PR TITLE
Fixed patching for Flatpak Steam installations

### DIFF
--- a/GModCEFCodecFix.py
+++ b/GModCEFCodecFix.py
@@ -210,8 +210,8 @@ else:
 
 	if os.path.isdir(os.path.join(homeDir, ".steam", "steam")):
 		steamPath = os.path.join(homeDir, ".steam", "steam")
-	elif os.path.isdir(os.path.join(homeDir, ".var", "app", "com.valvesoftware.Steam", ".steam", "steam")):
-		steamPath = os.path.join(homeDir, ".var", "app", "com.valvesoftware.Steam", ".steam", "steam")
+	elif os.path.isdir(os.path.join(homeDir, ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam")):
+		steamPath = os.path.join(homeDir, ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam")
 	elif os.path.isdir(os.path.join(dataDir, "Steam")):
 		steamPath = os.path.join(dataDir, "Steam")
 


### PR DESCRIPTION
This does not, however, resolve issues with bwrap or user namespaces when using Flatpak. It just resolves the issues with Steam install path detection.