### PR TITLE
Updated pathbuf_to_canonical_pathbuf to use dunce on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ecolor"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1597,7 @@ dependencies = [
  "blake3",
  "clap",
  "dirs",
+ "dunce",
  "eframe",
  "is_elevated",
  "keyvalues-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ zstd = "0.13.3"
 
 [target.'cfg(windows)'.dependencies]
 is_elevated = "0.1.2"
+dunce = "1.0.5"
 
 [target.'cfg(windows)'.build-dependencies]
 winresource = "0.1.22"

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,12 @@ fn pathbuf_dir_not_empty(pathbuf: &PathBuf) -> bool {
 }
 
 pub fn pathbuf_to_canonical_pathbuf(pathbuf: PathBuf, checkdirempty: bool) -> Result<PathBuf, String> {
-	let pathbuf_result = pathbuf.canonicalize();
+	#[cfg(target_os = "windows")]
+	use dunce::canonicalize;
+	#[cfg(not(target_os = "windows"))]
+	let canonicalize = Path::canonicalize;
+
+	let pathbuf_result = canonicalize(pathbuf.as_path());
 
 	if pathbuf_result.is_ok() {
 		let pathbuf = pathbuf_result.unwrap();


### PR DESCRIPTION
`Path::canonicalize` on the Windows platform will canonicalize to a UNC path, which is usually not what you want.
`dunce::canonicalize` does its best to resolve UNC paths back to a regular path.

Example

```rust
let path = Path::from(".\\Some Path");
assert_eq!(path.canonicalize().unwrap(), "\\?\C:\\Users\\User\\Some Path");
assert_eq!(dunce::canonicalize(path).unwrap(), "C:\\Users\\User\\Some Path");
```