### PR TITLE
Fix Chromium crashes on Proton and show embedded terminal progress

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -76,6 +76,10 @@ impl App {
 			backend: iced_term::settings::BackendSettings {
 				program,
 				args,
+				env: std::collections::HashMap::from([(
+					crate::patch::EMBEDDED_TERMINAL_ENV.to_owned(),
+					"1".to_owned(),
+				)]),
 				..Default::default()
 			},
 		};

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -47,6 +47,9 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle, ProgressDrawTarget};
 
 use super::vdf;
 
+#[cfg(target_os = "linux")]
+mod proton_appcontainer;
+
 // Live progress UI; bars register here so terminal_write can suspend them while printing
 static UI: OnceLock<MultiProgress> = OnceLock::new();
 
@@ -586,16 +589,22 @@ enum IntegrityStatus {
 	Fixed = 4
 }
 
-fn determine_file_integrity_status(gmod_path: PathBuf, filename: &str, hashes: &IndexMap<String, String>) -> Result<IntegrityStatus, String> {
+fn determine_file_integrity_status(gmod_path: PathBuf, filename: &str, hashes: &IndexMap<String, String>, accept_proton_appcontainer_hotfix: bool) -> Result<IntegrityStatus, String> {
 	let file_parts: Vec<&str> = filename.split("/").collect();
 	let file_path = path_to_canonical_pathbuf(extend_pathbuf_and_return(gmod_path, &file_parts[..]), false);
 	let mut file_hash = BLANK_FILE_HASH.to_string();
+	let mut proton_hotfix_matches = false;
 
-	if let Ok(file_path) = file_path {
+	if let Ok(file_path) = &file_path {
 		file_hash = get_file_hash(&file_path)?;
+
+		#[cfg(target_os = "linux")]
+		if accept_proton_appcontainer_hotfix && file_hash != hashes["fixed"] {
+			proton_hotfix_matches = proton_appcontainer::matches_hotfixed_file(file_path, filename, &hashes["fixed"])?;
+		}
 	}
 
-	if file_hash == hashes["fixed"] {
+	if file_hash == hashes["fixed"] || proton_hotfix_matches {
 		Ok(IntegrityStatus::Fixed)
 	} else {
 		// File needs to be fixed...
@@ -1491,6 +1500,7 @@ where
 	]);
 
 	#[allow(clippy::type_complexity)]
+	let accept_proton_appcontainer_hotfix = cfg!(target_os = "linux") && platform_masked == "windows";
 	let integrity_results: Vec<(&String, Result<IntegrityStatus, String>, &IndexMap<String, String>)> = platform_branch_files.par_iter()
 	.map(|(filename, hashes)| {
 		let integrity_result;
@@ -1498,7 +1508,7 @@ where
 			terminal_write(writer, format!("\t{filename}: Skipping due to --no-sourcescheme").as_str(), true, if writer_is_interactive { Some("yellow") } else { None });
 			integrity_result = Ok(IntegrityStatus::Fixed);
 		} else {
-			integrity_result = determine_file_integrity_status(gmod_path.clone(), filename, hashes);
+			integrity_result = determine_file_integrity_status(gmod_path.clone(), filename, hashes, accept_proton_appcontainer_hotfix);
 			let integrity_result_clone = integrity_result.clone();
 
 			match integrity_result_clone {
@@ -1688,6 +1698,30 @@ where
 		}
 	} else {
 		terminal_write(writer, "No files need patching!", true, None);
+	}
+
+	// CEF 137 directly imports an AppContainer API that Wine/Proton does not
+	// provide. Simulate the API's normal failure result on Proton only; do not
+	// disable CEF's sandbox or change native Windows installations.
+	#[cfg(target_os = "linux")]
+	if platform_masked == "windows" {
+		terminal_write(writer, "\nApplying Proton AppContainer compatibility fix...", true, None);
+
+		for filename in ["bin/win64/gmod.exe", "bin/gmod.exe"] {
+			let Some(hashes) = platform_branch_files.get(filename) else {
+				continue;
+			};
+
+			let file_parts: Vec<&str> = filename.split('/').collect();
+			let file_path = extend_pathbuf_and_return(gmod_path.clone(), &file_parts);
+			let result = proton_appcontainer::apply_to_file(&file_path, filename, &hashes["fixed"])
+				.map_err(|error| AlmightyError::Generic(format!("Failed to apply Proton AppContainer compatibility fix: {error}")))?;
+			let status = match result {
+				proton_appcontainer::ApplyResult::Applied => "Applied",
+				proton_appcontainer::ApplyResult::AlreadyApplied => "Already applied"
+			};
+			terminal_write(writer, format!("\t{filename}: {status}").as_str(), true, None);
+		}
 	}
 
 	// Make sure executables are executable on Linux and macOS

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -21,6 +21,7 @@ const SPINNER_FRAMES: &[&str] = &[
 	"⣤", "⣥", "⣦", "⣮", "⣶", "⣶", "\u{2800}", "⣶",
 ];
 const SPINNER_TICK: time::Duration = time::Duration::from_millis(100);
+pub(crate) const EMBEDDED_TERMINAL_ENV: &str = "GMODPATCHTOOL_EMBEDDED_TERMINAL";
 
 use crate::*;
 
@@ -43,7 +44,7 @@ use tokio::task::JoinSet;
 use qbsdiff::Bspatch;
 use regex::Regex;
 use std::sync::OnceLock;
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle, ProgressDrawTarget};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle, ProgressDrawTarget, TermLike};
 
 use super::vdf;
 
@@ -52,6 +53,80 @@ mod proton_appcontainer;
 
 // Live progress UI; bars register here so terminal_write can suspend them while printing
 static UI: OnceLock<MultiProgress> = OnceLock::new();
+
+#[derive(Debug)]
+struct EmbeddedStdoutTerm;
+
+impl EmbeddedStdoutTerm {
+	fn write(output: &[u8]) -> io::Result<()> {
+		use std::io::Write;
+		std::io::stdout().lock().write_all(output)
+	}
+
+	fn move_cursor(code: u8, distance: usize) -> io::Result<()> {
+		if distance == 0 {
+			return Ok(());
+		}
+
+		Self::write(format!("\x1b[{distance}{}", char::from(code)).as_bytes())
+	}
+}
+
+// The GUI child runs inside iced_term's PTY, but some desktop launch paths do
+// not report that PTY as an attended stdout to the console/indicatif crates.
+// This adapter is only selected for a child explicitly marked by the parent.
+impl TermLike for EmbeddedStdoutTerm {
+	fn width(&self) -> u16 {
+		crossterm::terminal::size().map(|size| size.0).unwrap_or(100)
+	}
+
+	fn height(&self) -> u16 {
+		crossterm::terminal::size().map(|size| size.1).unwrap_or(30)
+	}
+
+	fn move_cursor_up(&self, distance: usize) -> io::Result<()> {
+		Self::move_cursor(b'A', distance)
+	}
+
+	fn move_cursor_down(&self, distance: usize) -> io::Result<()> {
+		Self::move_cursor(b'B', distance)
+	}
+
+	fn move_cursor_right(&self, distance: usize) -> io::Result<()> {
+		Self::move_cursor(b'C', distance)
+	}
+
+	fn move_cursor_left(&self, distance: usize) -> io::Result<()> {
+		Self::move_cursor(b'D', distance)
+	}
+
+	fn write_line(&self, output: &str) -> io::Result<()> {
+		Self::write(format!("{output}\n").as_bytes())
+	}
+
+	fn write_str(&self, output: &str) -> io::Result<()> {
+		Self::write(output.as_bytes())
+	}
+
+	fn clear_line(&self) -> io::Result<()> {
+		Self::write(b"\r\x1b[2K")
+	}
+
+	fn flush(&self) -> io::Result<()> {
+		use std::io::Write;
+		std::io::stdout().lock().flush()
+	}
+}
+
+fn progress_draw_target(writer_is_interactive: bool, embedded_terminal: bool) -> ProgressDrawTarget {
+	if embedded_terminal {
+		ProgressDrawTarget::term_like_with_hz(Box::new(EmbeddedStdoutTerm), 20)
+	} else if writer_is_interactive {
+		ProgressDrawTarget::stdout()
+	} else {
+		ProgressDrawTarget::hidden()
+	}
+}
 
 fn spinner_style(template: &str) -> ProgressStyle {
 	ProgressStyle::with_template(template).unwrap().tick_strings(SPINNER_FRAMES).progress_chars("#>-")
@@ -934,7 +1009,7 @@ fn strip_localconfig_webstorage(localconfig: String) -> String {
 	localconfig
 }
 
-async fn main_script_internal<W>(writer: fn() -> W, writer_is_interactive: bool, args: Args) -> Result<(), AlmightyError>
+async fn main_script_internal<W>(writer: fn() -> W, writer_is_interactive: bool, embedded_terminal: bool, args: Args) -> Result<(), AlmightyError>
 where
 	W: std::io::Write + 'static
 {
@@ -942,11 +1017,7 @@ where
 	let mut sys = System::new_all();
 
 	// Set up the live progress UI; hidden when output isn't a terminal so we don't spam control codes
-	let _ = UI.set(MultiProgress::with_draw_target(if writer_is_interactive {
-		ProgressDrawTarget::stdout()
-	} else {
-		ProgressDrawTarget::hidden()
-	}));
+	let _ = UI.set(MultiProgress::with_draw_target(progress_draw_target(writer_is_interactive, embedded_terminal)));
 
 	// Figure out where our cache should go based on OS
 	let os_cache_dir = if let Some(dirs_cache_dir) = dirs::cache_dir() { dirs_cache_dir } else { std::env::temp_dir() };
@@ -1971,7 +2042,7 @@ fn terminal_exit_handler() {
 	delete_pid_lockfile();
 }
 
-fn main_script<W>(writer: fn() -> W, writer_is_interactive: bool, args: Args) -> Result<(), AlmightyError>
+fn main_script<W>(writer: fn() -> W, writer_is_interactive: bool, embedded_terminal: bool, args: Args) -> Result<(), AlmightyError>
 where
 	W: std::io::Write + 'static
 {
@@ -1987,7 +2058,7 @@ where
 				.build()
 				.map_err(|error| AlmightyError::Generic(format!("Failed to create Tokio runtime: {error}")))?
 				.block_on(
-					main_script_internal(writer, writer_is_interactive, args)
+					main_script_internal(writer, writer_is_interactive, embedded_terminal, args)
 				)
 		})
 		.map_err(|error| AlmightyError::Generic(format!("Failed to spawn patch thread: {error}")))?
@@ -2019,7 +2090,9 @@ pub fn main() {
 	fn supports_ansi() -> bool { true }
 
 	let is_terminal = io::stdout().is_terminal();
-	let is_ansi = is_terminal && supports_ansi();
+	let embedded_terminal = std::env::var_os(EMBEDDED_TERMINAL_ENV).as_deref() == Some(std::ffi::OsStr::new("1"));
+	let writer_is_interactive = is_terminal || embedded_terminal;
+	let is_ansi = writer_is_interactive && supports_ansi();
 
 	init_logger(is_ansi, std::io::stdout);
 
@@ -2074,7 +2147,6 @@ pub fn main() {
 	}
 
 	let writer = std::io::stdout;
-	let writer_is_interactive = is_terminal;
 
 	// Write about
 	terminal_write(writer, ABOUT, true, if writer_is_interactive { Some("cyan") } else { None });
@@ -2091,7 +2163,7 @@ pub fn main() {
 
 	let skip_exit_prompt = args.skip_exit_prompt;
 
-	let script_result = main_script(writer, writer_is_interactive, args);
+	let script_result = main_script(writer, writer_is_interactive, embedded_terminal, args);
 	if let Err(error) = &script_result {
 		error!("{error}");
 	}

--- a/src/patch/proton_appcontainer.rs
+++ b/src/patch/proton_appcontainer.rs
@@ -181,11 +181,20 @@ fn normalized_hotfix_hash(bytes: &[u8], filename: &str) -> Result<Option<String>
 		return Ok(None);
 	};
 
-	if all_sites_match(bytes, sites, false) {
+	let replacement_count = sites
+		.iter()
+		.filter(|site| {
+			bytes.get(site.offset..site.offset + site.replacement.len()) == Some(site.replacement)
+		})
+		.count();
+
+	// A vanilla executable has an entirely different layout. It still needs the
+	// normal manifest patch before this compatibility fix can be considered.
+	if replacement_count == 0 {
 		return Ok(None);
 	}
 
-	if !all_sites_match(bytes, sites, true) {
+	if replacement_count != sites.len() {
 		return Err(format!(
 			"{filename} has a partial or unknown Proton AppContainer compatibility patch"
 		));
@@ -341,6 +350,15 @@ mod tests {
 			normalized_hotfix_hash(&bytes, "bin/win64/gmod.exe")
 				.unwrap_err()
 				.contains("partial or unknown")
+		);
+	}
+
+	#[test]
+	fn vanilla_executable_layout_is_left_for_the_manifest_patcher() {
+		let bytes = vec![0_u8; X86_64_SITES.last().unwrap().offset + 16];
+		assert_eq!(
+			normalized_hotfix_hash(&bytes, "bin/win64/gmod.exe").unwrap(),
+			None
 		);
 	}
 }

--- a/src/patch/proton_appcontainer.rs
+++ b/src/patch/proton_appcontainer.rs
@@ -1,0 +1,346 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+// Chromium 137's AppContainer helper hard-imports this Windows API. Wine/Proton
+// installs an exception-raising import stub when the export is absent, so the
+// process crashes instead of reaching Chromium's normal HRESULT failure path.
+//
+// Keep CEF's sandbox enabled. On Proton only, these patches make the four calls
+// return HRESULT_FROM_WIN32(ERROR_PROC_NOT_FOUND). Chromium then declines the
+// unavailable AppContainer profile while retaining its other sandbox layers.
+const PROC_NOT_FOUND_HRESULT: [u8; 4] = 0x8007_007f_u32.to_le_bytes();
+const REQUIRED_IMPORT: &[u8] = b"DeriveAppContainerSidFromAppContainerName\0";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApplyResult {
+	Applied,
+	AlreadyApplied,
+}
+
+#[derive(Clone, Copy)]
+struct PatchSite {
+	offset: usize,
+	original: &'static [u8],
+	replacement: &'static [u8],
+}
+
+const X86_64_SITES: &[PatchSite] = &[
+	PatchSite {
+		offset: 0x37c34,
+		original: &[0xff, 0x15, 0x9e, 0x98, 0x2b, 0x00],
+		replacement: &[
+			0xb8,
+			PROC_NOT_FOUND_HRESULT[0],
+			PROC_NOT_FOUND_HRESULT[1],
+			PROC_NOT_FOUND_HRESULT[2],
+			PROC_NOT_FOUND_HRESULT[3],
+			0x90,
+		],
+	},
+	PatchSite {
+		offset: 0x38207,
+		original: &[0xff, 0x15, 0xcb, 0x92, 0x2b, 0x00],
+		replacement: &[
+			0xb8,
+			PROC_NOT_FOUND_HRESULT[0],
+			PROC_NOT_FOUND_HRESULT[1],
+			PROC_NOT_FOUND_HRESULT[2],
+			PROC_NOT_FOUND_HRESULT[3],
+			0x90,
+		],
+	},
+	PatchSite {
+		offset: 0x384d6,
+		original: &[0xff, 0x15, 0xfc, 0x8f, 0x2b, 0x00],
+		replacement: &[
+			0xb8,
+			PROC_NOT_FOUND_HRESULT[0],
+			PROC_NOT_FOUND_HRESULT[1],
+			PROC_NOT_FOUND_HRESULT[2],
+			PROC_NOT_FOUND_HRESULT[3],
+			0x90,
+		],
+	},
+	PatchSite {
+		offset: 0x387ab,
+		original: &[0xff, 0x15, 0x27, 0x8d, 0x2b, 0x00],
+		replacement: &[
+			0xb8,
+			PROC_NOT_FOUND_HRESULT[0],
+			PROC_NOT_FOUND_HRESULT[1],
+			PROC_NOT_FOUND_HRESULT[2],
+			PROC_NOT_FOUND_HRESULT[3],
+			0x90,
+		],
+	},
+];
+
+// x86 stdcall would normally pop its two arguments in the callee. Replace the
+// two one-byte pushes as well as the call so the stack remains balanced. The
+// short jump skips a per-site marker byte, which lets us restore the exact
+// vendor bytes when normalizing the manifest checksum on later runs.
+const X86_SITES: &[PatchSite] = &[
+	PatchSite {
+		offset: 0x313c9,
+		original: &[0x51, 0x50, 0xff, 0x15, 0x70, 0x80, 0x69, 0x00],
+		replacement: &[
+			0xb8,
+			PROC_NOT_FOUND_HRESULT[0],
+			PROC_NOT_FOUND_HRESULT[1],
+			PROC_NOT_FOUND_HRESULT[2],
+			PROC_NOT_FOUND_HRESULT[3],
+			0xeb,
+			0x01,
+			0xa1,
+		],
+	},
+	PatchSite {
+		offset: 0x3193d,
+		original: &[0x57, 0x50, 0xff, 0x15, 0x70, 0x80, 0x69, 0x00],
+		replacement: &[
+			0xb8,
+			PROC_NOT_FOUND_HRESULT[0],
+			PROC_NOT_FOUND_HRESULT[1],
+			PROC_NOT_FOUND_HRESULT[2],
+			PROC_NOT_FOUND_HRESULT[3],
+			0xeb,
+			0x01,
+			0xa2,
+		],
+	},
+	PatchSite {
+		offset: 0x31b89,
+		original: &[0x51, 0x50, 0xff, 0x15, 0x70, 0x80, 0x69, 0x00],
+		replacement: &[
+			0xb8,
+			PROC_NOT_FOUND_HRESULT[0],
+			PROC_NOT_FOUND_HRESULT[1],
+			PROC_NOT_FOUND_HRESULT[2],
+			PROC_NOT_FOUND_HRESULT[3],
+			0xeb,
+			0x01,
+			0xa3,
+		],
+	},
+	PatchSite {
+		offset: 0x31de9,
+		original: &[0x50, 0x57, 0xff, 0x15, 0x70, 0x80, 0x69, 0x00],
+		replacement: &[
+			0xb8,
+			PROC_NOT_FOUND_HRESULT[0],
+			PROC_NOT_FOUND_HRESULT[1],
+			PROC_NOT_FOUND_HRESULT[2],
+			PROC_NOT_FOUND_HRESULT[3],
+			0xeb,
+			0x01,
+			0xa4,
+		],
+	},
+];
+
+fn sites_for(filename: &str) -> Option<&'static [PatchSite]> {
+	match filename {
+		"bin/win64/gmod.exe" => Some(X86_64_SITES),
+		"bin/gmod.exe" => Some(X86_SITES),
+		_ => None,
+	}
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+	haystack
+		.windows(needle.len())
+		.any(|window| window == needle)
+}
+
+fn all_sites_match(bytes: &[u8], sites: &[PatchSite], replacement: bool) -> bool {
+	sites.iter().all(|site| {
+		let expected = if replacement {
+			site.replacement
+		} else {
+			site.original
+		};
+		bytes.get(site.offset..site.offset + expected.len()) == Some(expected)
+	})
+}
+
+fn replace_sites(bytes: &mut [u8], sites: &[PatchSite], apply: bool) {
+	for site in sites {
+		let (from, to) = if apply {
+			(site.original, site.replacement)
+		} else {
+			(site.replacement, site.original)
+		};
+		debug_assert_eq!(bytes.get(site.offset..site.offset + from.len()), Some(from));
+		bytes[site.offset..site.offset + to.len()].copy_from_slice(to);
+	}
+}
+
+fn normalized_hotfix_hash(bytes: &[u8], filename: &str) -> Result<Option<String>, String> {
+	let Some(sites) = sites_for(filename) else {
+		return Ok(None);
+	};
+
+	if all_sites_match(bytes, sites, false) {
+		return Ok(None);
+	}
+
+	if !all_sites_match(bytes, sites, true) {
+		return Err(format!(
+			"{filename} has a partial or unknown Proton AppContainer compatibility patch"
+		));
+	}
+
+	let mut normalized = bytes.to_vec();
+	replace_sites(&mut normalized, sites, false);
+	Ok(Some(blake3::hash(&normalized).to_string()))
+}
+
+pub fn matches_hotfixed_file(
+	file_path: &Path,
+	filename: &str,
+	expected_fixed_hash: &str,
+) -> Result<bool, String> {
+	if sites_for(filename).is_none() {
+		return Ok(false);
+	}
+
+	let bytes = std::fs::read(file_path).map_err(|error| error.to_string())?;
+	Ok(normalized_hotfix_hash(&bytes, filename)?.as_deref() == Some(expected_fixed_hash))
+}
+
+fn atomic_write(file_path: &Path, bytes: &[u8]) -> Result<(), String> {
+	let metadata = std::fs::metadata(file_path).map_err(|error| error.to_string())?;
+	let mut temporary_path = PathBuf::from(file_path);
+	let temporary_extension = format!("gmodpatchtool-{}.tmp", std::process::id());
+	temporary_path.set_extension(temporary_extension);
+
+	let write_result = (|| -> Result<(), std::io::Error> {
+		let mut temporary_file = OpenOptions::new()
+			.write(true)
+			.create_new(true)
+			.open(&temporary_path)?;
+		temporary_file.write_all(bytes)?;
+		temporary_file.sync_all()?;
+		std::fs::set_permissions(&temporary_path, metadata.permissions())?;
+		std::fs::rename(&temporary_path, file_path)
+	})();
+
+	if let Err(error) = write_result {
+		let _ = std::fs::remove_file(&temporary_path);
+		return Err(error.to_string());
+	}
+
+	Ok(())
+}
+
+pub fn apply_to_file(
+	file_path: &Path,
+	filename: &str,
+	expected_fixed_hash: &str,
+) -> Result<ApplyResult, String> {
+	let sites = sites_for(filename).ok_or_else(|| {
+		format!("No Proton AppContainer compatibility patch is defined for {filename}")
+	})?;
+	let mut bytes = std::fs::read(file_path).map_err(|error| error.to_string())?;
+
+	if !contains_bytes(&bytes, REQUIRED_IMPORT) {
+		return Err(format!(
+			"{filename} does not import DeriveAppContainerSidFromAppContainerName"
+		));
+	}
+
+	if all_sites_match(&bytes, sites, true) {
+		let normalized_hash = normalized_hotfix_hash(&bytes, filename)?;
+		if normalized_hash.as_deref() != Some(expected_fixed_hash) {
+			return Err(format!(
+				"{filename} does not match the manifest after normalizing its Proton AppContainer compatibility patch"
+			));
+		}
+
+		return Ok(ApplyResult::AlreadyApplied);
+	}
+
+	let actual_hash = blake3::hash(&bytes).to_string();
+	if actual_hash != expected_fixed_hash {
+		return Err(format!(
+			"Refusing to modify {filename}: its checksum does not match the manifest"
+		));
+	}
+
+	if !all_sites_match(&bytes, sites, false) {
+		return Err(format!(
+			"Refusing to modify {filename}: this GMod/Chromium executable layout is not supported"
+		));
+	}
+
+	replace_sites(&mut bytes, sites, true);
+	atomic_write(file_path, &bytes)?;
+	Ok(ApplyResult::Applied)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn fixture_for(sites: &[PatchSite]) -> Vec<u8> {
+		let mut bytes = vec![
+			0_u8;
+			sites
+				.iter()
+				.map(|site| site.offset + site.original.len())
+				.max()
+				.unwrap()
+		];
+		for site in sites {
+			bytes[site.offset..site.offset + site.original.len()].copy_from_slice(site.original);
+		}
+		bytes
+	}
+
+	#[test]
+	fn x86_64_patch_round_trips_for_manifest_hashing() {
+		let original = fixture_for(X86_64_SITES);
+		let expected_hash = blake3::hash(&original).to_string();
+		let mut patched = original.clone();
+		replace_sites(&mut patched, X86_64_SITES, true);
+
+		assert_ne!(patched, original);
+		assert_eq!(
+			normalized_hotfix_hash(&patched, "bin/win64/gmod.exe")
+				.unwrap()
+				.as_deref(),
+			Some(expected_hash.as_str())
+		);
+	}
+
+	#[test]
+	fn x86_patch_skips_argument_pushes_and_round_trips() {
+		let original = fixture_for(X86_SITES);
+		let expected_hash = blake3::hash(&original).to_string();
+		let mut patched = original.clone();
+		replace_sites(&mut patched, X86_SITES, true);
+
+		assert!(X86_SITES.iter().all(|site| patched[site.offset] == 0xb8
+			&& patched[site.offset + 5..site.offset + 7] == [0xeb, 0x01]));
+		assert_eq!(
+			normalized_hotfix_hash(&patched, "bin/gmod.exe")
+				.unwrap()
+				.as_deref(),
+			Some(expected_hash.as_str())
+		);
+	}
+
+	#[test]
+	fn partial_patch_is_rejected() {
+		let mut bytes = fixture_for(X86_64_SITES);
+		bytes[X86_64_SITES[0].offset..X86_64_SITES[0].offset + X86_64_SITES[0].replacement.len()]
+			.copy_from_slice(X86_64_SITES[0].replacement);
+
+		assert!(
+			normalized_hotfix_hash(&bytes, "bin/win64/gmod.exe")
+				.unwrap_err()
+				.contains("partial or unknown")
+		);
+	}
+}

--- a/src/patch/tests.rs
+++ b/src/patch/tests.rs
@@ -64,3 +64,9 @@ fn loginusers_missing_mostrecent_and_timestamp() {
 	assert_eq!(user.timestamp, 0);
 	assert_eq!(user.account_name, "someuser");
 }
+
+#[test]
+fn embedded_terminal_forces_visible_progress_target() {
+	assert!(!progress_draw_target(false, true).is_hidden());
+	assert!(progress_draw_target(false, false).is_hidden());
+}


### PR DESCRIPTION
## What changed

This adds a Linux-only compatibility fix for a Chromium AppContainer API that Wine/Proton does not currently support. It handles both the 32-bit and 64-bit GMod executables and makes sure already-patched files still pass the integrity check.

This also fixes progress bars not appearing in the embedded Linux terminal.

## Why

CEF 137 imports `DeriveAppContainerSidFromAppContainerName` directly. Wine/Proton replaces the missing API with a stub that raises an exception, which causes Chromium to crash instead of handling the failure normally.

The patch replaces those calls with the error result Chromium expects when AppContainer is unavailable. It does not completely disable Chromium's sandbox.

## Testing

I ran a DHTML-heavy workload for 10 minutes without any crashes. Before this fix, it would usually crash within around 3 minutes.

There are also tests covering:

- The 32-bit and 64-bit executable patches
- Already-patched and partially patched files
- Clean executables passing through normal patching
- Progress-bar visibility in the embedded terminal

`git diff --check` passes. I could not run the full Cargo test suite because `GModPatchToolLogo.png` is currently an unresolved Git LFS pointer in this checkout.

## A note about the sandbox

I am not completely sure whether making the AppContainer profile unavailable could affect some sandboxed Chromium instances. However, this does not disable the Chromium sandbox entirely, and the other sandbox layers remain enabled. I am happy with that trade-off for now, but it could use more testing.
